### PR TITLE
Optimize rxjs imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "leaflet-rxjs",
+  "version": "0.1.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "leaflet": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.3.1.tgz",
+      "integrity": "sha512-adQOIzh+bfdridLM1xIgJ9VnJbAUY3wqs/ueF+ITla+PLQ1z47USdBKUf+iD9FuUA8RtlT6j6hZBfZoA6mW+XQ=="
+    },
+    "rxjs": {
+      "version": "5.5.10",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.10.tgz",
+      "integrity": "sha512-SRjimIDUHJkon+2hFo7xnvNC4ZEHGzCRwh9P7nzX3zPkCGFEg/tuElrNR7L/rZMagnK2JeH2jQwPRpmyXyLB6A==",
+      "requires": {
+        "symbol-observable": "1.0.1"
+      }
+    },
+    "symbol-observable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+      "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
+    }
+  }
+}


### PR DESCRIPTION
I used this package in Angular 5 project, line `define(['leaflet', 'rxjs'], factory);` caused webpack to include whole *rxjs* library into bundle. This resulted in 900KB instead of 100KB that is actually needed in my project.